### PR TITLE
Use env to find bash, instead of relying on fixed path

### DIFF
--- a/ydm-install
+++ b/ydm-install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install and initialize
 dir="${0%/*}"
 config="$dir/.config"


### PR DESCRIPTION
This is necessarry on Nixos systems, and rest of the OS's which don't use standart file structure.